### PR TITLE
Shared object fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,6 +85,7 @@ elseif(WIN32)
   endif()
 
 elseif(UNIX)
+ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
   ## ALSA support ##
   if(NOT RTMIDI17_NO_ALSA)
     find_package(ALSA)


### PR DESCRIPTION
When trying to build on Linux for distribution I get the following error, 

/usr/bin/ld: RtMidi17/libRtMidi17.a(rtmidi17.cpp.o): relocation R_X86_64_PC32 against symbol `_ZTVN6rtmidi14midi_exceptionE' can not be used when making a shared object; recompile with -fPIC

This fixes that.